### PR TITLE
feat : Add custom error message

### DIFF
--- a/app/Http/Controllers/ShortenLinkController.php
+++ b/app/Http/Controllers/ShortenLinkController.php
@@ -48,8 +48,14 @@ class ShortenLinkController extends Controller
     {
         $request->validate([
             'original_url' => 'required|url',
-            'custom_alias' => 'nullable|string',
+            'custom_alias' => [
+                'nullable',
+                'string',
+                'regex:/^[A-Za-z0-9\-_]+$/',
+            ],
             'expires_at' => 'nullable|date|after:' . now()->addMinute(),
+        ], [
+            'custom_alias.regex' => 'Alias can only contain letters, numbers, dashes (-), or underscores (_), no spaces.',
         ]);
 
         $alias = $request->custom_alias ?? Str::random(6);

--- a/resources/js/Components/Alert/CreateProject.jsx
+++ b/resources/js/Components/Alert/CreateProject.jsx
@@ -32,7 +32,6 @@ export default function CreateProject({ show, onClose }) {
                     type: "error",
                     message: "An error occurred, please check your input.",
                 });
-                 reset();
             },
         });
     };
@@ -118,7 +117,7 @@ export default function CreateProject({ show, onClose }) {
                                     onChange={(e) =>
                                         setData("project_slug", e.target.value)
                                     }
-                                    required
+                                    
                                 />
                                 {errors.project_slug && (
                                     <div className="text-red-500 text-sm mt-1">


### PR DESCRIPTION
Add custom error message 'custom_alias.regex' => 'Alias can only contain letters, numbers, dashes (-), or underscores (_), no spaces.'.