### PR TITLE
feat : improve email validation and implement 'Remember Me'

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -27,32 +27,42 @@ class AuthenticatedSessionController extends Controller
     /**
      * Handle an incoming authentication request.
      */
+    public function store(LoginRequest $request): RedirectResponse
+    {
+        $credentials = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required'],
+        ]);
+
+        $remember = $request->boolean('remember');
+
+        if (!Auth::attempt($credentials, $remember)) {
+            return back()->withErrors([
+                'email' => 'The provided credentials do not match our records.',
+            ])->onlyInput('email');
+        }
+
+        $request->session()->regenerate();
+
+        return redirect()->intended(route('projects.index', absolute: false));
+    }
+    
     // public function store(LoginRequest $request): RedirectResponse
     // {
     //     $request->authenticate();
 
     //     $request->session()->regenerate();
 
+    //     // Kirim ulang email verifikasi secara otomatis jika belum verifikasi
+    //     if (!$request->user()->hasVerifiedEmail()) {
+    //         $request->user()->sendEmailVerificationNotification();
+
+    //         return redirect()->route('verification.notice')
+    //             ->with('status', 'verification-link-sent');
+    //     }
+
     //     return redirect()->intended(route('projects.index', absolute: false));
     // }
-    public function store(LoginRequest $request): RedirectResponse
-    {
-        $request->authenticate();
-
-        $request->session()->regenerate();
-
-        // Kirim ulang email verifikasi secara otomatis jika belum verifikasi
-        if (!$request->user()->hasVerifiedEmail()) {
-            $request->user()->sendEmailVerificationNotification();
-
-            return redirect()->route('verification.notice')
-                ->with('status', 'verification-link-sent');
-        }
-
-        return redirect()->intended(route('projects.index', absolute: false));
-    }
-
-
 
     /**
      * Destroy an authenticated session.

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -55,8 +55,8 @@ class RegisteredUserController extends Controller
 
         event(new Registered($user));
 
-        Auth::login($user);
+        // Auth::login($user);
 
-        return redirect()->route('verification.notice');
+        return redirect(route('login', absolute: false));
     }
 }

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -75,7 +75,7 @@ class CategoryController extends Controller
 
         $request->validate([
             'name' => 'required|string|max:255',
-            'image' => 'nullable|image|mimes:jpg,jpeg,png,webp|max:1024',
+            'image' => 'required|image|mimes:jpg,jpeg,png,webp|max:1024',
         ]);
 
         $project = Project::where('id', $projectId)
@@ -132,7 +132,7 @@ class CategoryController extends Controller
 
         $validated = $request->validate([
             'name' => 'required|string|max:255|filled',
-            'image' => 'nullable|image|mimes:jpg,jpeg,png,webp|max:1024',
+            'image' => 'required|image|mimes:jpg,jpeg,png,webp|max:1024',
         ]);
 
         $project = Project::where('id', $projectId)

--- a/app/Http/Controllers/ShortenLinkController.php
+++ b/app/Http/Controllers/ShortenLinkController.php
@@ -52,7 +52,7 @@ class ShortenLinkController extends Controller
                 'string',
                 'regex:/^[A-Za-z0-9\-_]+$/',
             ],
-            'expires_at' => 'nullable|date|after:' . now()->addMinute(),
+            'expires_at' => 'required|date|after:' . now()->addMinute(),
         ], [
             'custom_alias.regex' => 'Alias can only contain letters, numbers, dashes (-), or underscores (_), no spaces.',
         ]);
@@ -108,7 +108,7 @@ class ShortenLinkController extends Controller
                 'alpha_dash',
                 Rule::unique('shortened_links', 'custom_alias')->ignore($link->id),
             ],
-            'expires_at' => 'nullable|date|after:' . now()->addMinute(),
+            'expires_at' => 'required|date|after:' . now()->addMinute(),
         ]);
 
         $alias = $request->custom_alias;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,9 +6,8 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
-use Illuminate\Contracts\Auth\MustVerifyEmail;
 
-class User extends Authenticatable implements MustVerifyEmail
+class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasFactory, Notifiable;

--- a/resources/js/Components/Alert/CreateCategories.jsx
+++ b/resources/js/Components/Alert/CreateCategories.jsx
@@ -124,6 +124,7 @@ export default function CreateCategories({ show, onClose, project }) {
                                 accept="image/*"
                                 className="w-full border border-brfourth rounded-lg px-3 py-2 mt-1"
                                 onChange={handleImageChange}
+                                required
                             />
                             <p className="text-xs text-gray-500 mt-1">
                                 Recommended format: JPG, PNG, or WEBP. Maximum size: 1 MB.

--- a/resources/js/Components/Alert/CreateShortlink.jsx
+++ b/resources/js/Components/Alert/CreateShortlink.jsx
@@ -10,7 +10,7 @@ export default function CreateShortlink({
     setData,
     errors,
     processing,
-    post,      
+    post,
     reset,
 }) {
     const [notification, setNotification] = useState(null);
@@ -116,7 +116,7 @@ export default function CreateShortlink({
                                     onChange={(e) =>
                                         setData("custom_alias", e.target.value)
                                     }
-                                    // required
+                                // required
                                 />
                                 {errors.custom_alias && (
                                     <div className="text-red-500 text-sm mt-1">
@@ -155,6 +155,3 @@ export default function CreateShortlink({
         </div>
     );
 }
-
-
-

--- a/resources/js/Components/Alert/UpdateCategories.jsx
+++ b/resources/js/Components/Alert/UpdateCategories.jsx
@@ -43,7 +43,7 @@ export default function UpdateCategories({ show, onClose, project, category }) {
             setData("image", file);
             setImagePreview(URL.createObjectURL(file));
         }
-    };    
+    };
 
     const handleSubmit = (e) => {
         e.preventDefault();
@@ -109,9 +109,12 @@ export default function UpdateCategories({ show, onClose, project, category }) {
                             placeholder="Example"
                             value={data.name}
                             onChange={(e) => setData("name", e.target.value)}
+                            required
                         />
                         {errors.name && (
-                            <div className="text-red-500 text-sm mt-1">{errors.name}</div>
+                            <div className="text-red-500 text-sm mt-1">
+                                {errors.name}
+                            </div>
                         )}
                     </div>
 
@@ -122,12 +125,15 @@ export default function UpdateCategories({ show, onClose, project, category }) {
                             accept="image/*"
                             className="w-full border border-brfourth rounded-lg px-3 py-2 mt-1"
                             onChange={handleFileChange}
+                            required
                         />
                         <p className="text-xs text-gray-500 mt-1">
                             Recommended format: JPG, PNG, or WEBP. Max size: 1 MB.
                         </p>
                         {errors.image && (
-                            <div className="text-red-500 text-sm mt-1">{errors.image}</div>
+                            <div className="text-red-500 text-sm mt-1">
+                                {errors.image}
+                            </div>
                         )}
                         {imagePreview && (
                             <img

--- a/resources/js/Pages/Auth/Login.jsx
+++ b/resources/js/Pages/Auth/Login.jsx
@@ -104,14 +104,14 @@ export default function Login({ status, canResetPassword }) {
                         </span>
                     </label>
 
-                    {canResetPassword && (
+                    {/* {canResetPassword && (
                         <Link
                             href={route("password.request")}
                             className="text-xs md:text-sm font-medium text-primary-100 hover:text-secondary"
                         >
                             Forgot Password?
                         </Link>
-                    )}
+                    )} */}
                 </div>
 
                 <div className="mt-4 flex items-center ">

--- a/resources/js/Pages/Shorten/Edit.jsx
+++ b/resources/js/Pages/Shorten/Edit.jsx
@@ -180,7 +180,7 @@ const EditUrlPage = ({ auth, link }) => {
                             <input
                                 type="text"
                                 className="w-full border border-brfourth rounded-lg px-3 py-2 mt-1 bg-white text-gray-700"
-                                value={`sevenpion.com/s/`}
+                                value={`${window.location.origin}/m/`}
                                 readOnly
                             />
                         </div>


### PR DESCRIPTION
- Take down feature VerifyEmail
- Enhanced validation in CreateCategories and others 
- Replaced LoginRequest with manual validation and Auth::attempt in login logic
- Added support for 'remember me' checkbox to persist user sessions
- Ensured session regeneration after successful login